### PR TITLE
Unit tests for add.js

### DIFF
--- a/test/add.test.js
+++ b/test/add.test.js
@@ -29,18 +29,8 @@ describe('Add', () => {
         expect(add(1e20, 1e20)).to.equal(2e20);
     });
 
-    // Is this the wanted behaviour of the function?
-    it('should add string conversions', () => {
-        expect(add('3', '4')).to.equal('34');
-    });
-
     it('should handle missing arguments', () => {
         expect(add(5)).to.equal(5);
         expect(add()).to.equal(0);
-    });
-
-    // Is this the wanted behaviour of the function?
-    it('should handle non-numeric values', () => {
-        expect(add('abc', 5)).to.equal('abc5');
     });
 });

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -3,10 +3,44 @@ import add from '../src/add.js';
 
 var expect = chai.expect;
 
-describe('add', () => {
-    it('should add two numbers', () => {
+describe('Add', () => {
+    it('should add two positive numbers', () => {
         expect(add(6, 4)).to.equal(10);
+        expect(add(2, 2)).to.equal(4);
+    });
+
+    it('should handle negative numbers correctly', () => {
         expect(add(-6, 4)).to.equal(-2);
         expect(add(6, -4)).to.equal(2);
+        expect(add(-2, -2)).to.equal(-4);
+    });
+
+    it('should handle zero values correctly', () => {
+        expect(add(0, 0)).to.equal(0);
+        expect(add(2, 0)).to.equal(2);
+    });
+
+    it('should add decimal numbers', () => {
+        expect(add(1.5, 2.5)).to.equal(4);
+        expect(add(0.1, 0.2)).to.be.closeTo(0.3, 10);
+    });
+
+    it('should add large numbers', () => {
+        expect(add(1e20, 1e20)).to.equal(2e20);
+    });
+
+    // Is this the wanted behaviour of the function?
+    it('should add string conversions', () => {
+        expect(add('3', '4')).to.equal('34');
+    });
+
+    it('should handle missing arguments', () => {
+        expect(add(5)).to.equal(5);
+        expect(add()).to.equal(0);
+    });
+
+    // Is this the wanted behaviour of the function?
+    it('should handle non-numeric values', () => {
+        expect(add('abc', 5)).to.equal('abc5');
     });
 });


### PR DESCRIPTION
Parissa testissä kommentit. En oikein tiiä pitäiskö ne jättää kokonaan pois, jättää tollasenaan (jos add.js kuuluu toimia noin) vai muokata testit niin et add.js ei lähde yhdistään stringejä ja antaa noiden parin testin feilata (eli olis löydettynä bugi)? :D