### PR TITLE
Ceil.js and defaultTo.js unit tests

### DIFF
--- a/test/ceil.test.js
+++ b/test/ceil.test.js
@@ -1,0 +1,38 @@
+import chai from 'chai';
+import ceil from '../src/ceil.js';
+
+var expect = chai.expect;
+
+describe('ceil', () => {
+    it('should round up positive numbers to the nearest integer', () => {
+        expect(ceil(4.006)).to.equal(5);
+        expect(ceil(6.004, 2)).to.equal(6.01);
+        expect(ceil(6040, -2)).to.equal(6100);
+    });
+
+    it('should round up negative numbers to the nearest integer', () => {
+        expect(ceil(-4.006)).to.equal(-4);
+        expect(ceil(-6.004, 2)).to.equal(-6);
+        expect(ceil(-6040, -2)).to.equal(-6000);
+    });
+
+    it('should handle precision of 0', () => {
+        expect(ceil(4.006, 0)).to.equal(5);
+        expect(ceil(-4.004, 0)).to.equal(-4);
+    });
+
+    it('should handle infinity', () => {
+        expect(ceil(Infinity)).to.equal(Infinity);
+        expect(ceil(-Infinity)).to.equal(-Infinity);
+    });
+
+    it('should return NaN for invalid inputs', () => {
+        expect(isNaN(ceil('invalid'))).to.equal(true);
+        expect(isNaN(ceil(undefined))).to.equal(true);
+        expect(isNaN(ceil(NaN))).to.equal(true);
+    });
+
+    it('should return 0 for null input', () => {
+        expect(ceil(null)).to.equal(0);
+    });
+});

--- a/test/defaultTo.test.js
+++ b/test/defaultTo.test.js
@@ -1,0 +1,32 @@
+import chai from 'chai';
+import defaultTo from '../src/defaultTo.js';
+
+var expect = chai.expect;
+
+describe('defaultTo', () => {
+    it('should return the value if not NaN, null, or undefined', () => {
+        expect(defaultTo(1, 10)).to.equal(1);
+        expect(defaultTo('hello', 'world')).to.equal('hello');
+        expect(defaultTo(false, true)).to.equal(false);
+    });
+
+    it('should return the default value if value is NaN, null, or undefined', () => {
+        expect(defaultTo(undefined, 10)).to.equal(10);
+        expect(defaultTo(null, 'default')).to.equal('default');
+        
+        // should work this way but doesn't
+        //expect(defaultTo(NaN, 'fallback')).to.equal('fallback');
+
+        expect(defaultTo(undefined, null)).to.equal(null);
+    });
+
+    it('should return value when value is a function', () => {
+        const func = () => {};
+        expect(defaultTo(func, 'fallback')).to.equal(func);
+    });
+
+    it('should return the value if it is an object', () => {
+        const obj = { key: 'value' };
+        expect(defaultTo(obj, {})).to.equal(obj);
+    });
+});

--- a/test/defaultTo.test.js
+++ b/test/defaultTo.test.js
@@ -13,10 +13,7 @@ describe('defaultTo', () => {
     it('should return the default value if value is NaN, null, or undefined', () => {
         expect(defaultTo(undefined, 10)).to.equal(10);
         expect(defaultTo(null, 'default')).to.equal('default');
-        
-        // should work this way but doesn't
-        //expect(defaultTo(NaN, 'fallback')).to.equal('fallback');
-
+        expect(defaultTo(NaN, 'fallback')).to.equal('fallback');
         expect(defaultTo(undefined, null)).to.equal(null);
     });
 


### PR DESCRIPTION
defaultTo.js testien kanssa taas ihanasti mahdollinen bugi :D NaN arvon pitäis palauttaa annettu defaultarvo mutta eipä palauta. Taas kerran tämä et voikohan tonne jättää testejä jotka ei mee läpi. Varsinki nyt kun selvästi ei toimi niinku pitäis ＼（〇_ｏ）／